### PR TITLE
Fix remote

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -89,14 +89,14 @@ function () {
     this.tvService.setCharacteristic(Characteristic.ConfiguredName, this.name);
     this.tvService.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
     this.tvService.getCharacteristic(Characteristic.Active).on("set", this.setPowerState.bind(this)).on("get", this.getPowerState.bind(this));
-    this.tvService.getCharacteristic(Characteristic.RemoteKey).on("set", this.setRemoteKey);
+    this.tvService.getCharacteristic(Characteristic.RemoteKey).on("set", this.setRemoteKey.bind(this));
     this.tvService.getCharacteristic(Characteristic.PowerModeSelection).on('set', function (newValue, callback) {
       _this.log.debug('SkyQ - requested tv settings (PowerModeSelection): ' + newValue);
 
       console.log('SkyQ - requested tv settings (PowerModeSelection): ' + newValue);
     }); //this.tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
 
-    this.tvService.getCharacteristic(Characteristic.ActiveIdentifier).on("set", this.setRemoteKey);
+    this.tvService.getCharacteristic(Characteristic.ActiveIdentifier).on("set", this.setRemoteKey.bind(this));
     this.inputSkyQService = new Service.InputSource("skyq", "Sky Q");
     this.inputSkyQService.setCharacteristic(Characteristic.Identifier, 0).setCharacteristic(Characteristic.ConfiguredName, "Sky Q").setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED).setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.HOME_SCREEN);
     this.tvService.addLinkedService(this.inputSkyQService);
@@ -124,8 +124,7 @@ function () {
     key: "setRemoteKey",
     value: function setRemoteKey(state, callback) {
       console.log("input", state);
-      var platform = this;
-      platform.log("Setting key state...");
+      this.log("Setting key state...");
       var input_key;
 
       switch (state) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ class SkyQAccessory {
   box: any;
   remoteControl: any;
   inputSkyQService: any;
-  
+
   constructor(log, config) {
     this.log = log;
     this.enabledServices = [];
@@ -50,23 +50,22 @@ class SkyQAccessory {
 
 
     this.tvService
-    .getCharacteristic(Characteristic.RemoteKey)
-    .on("set", this.setRemoteKey);
+      .getCharacteristic(Characteristic.RemoteKey)
+      .on("set", this.setRemoteKey);
 
     this.tvService
-    .getCharacteristic(Characteristic.PowerModeSelection)
-    .on('set', (newValue, callback) => {
+      .getCharacteristic(Characteristic.PowerModeSelection)
+      .on('set', (newValue, callback) => {
         this.log.debug('SkyQ - requested tv settings (PowerModeSelection): ' + newValue);
         console.log('SkyQ - requested tv settings (PowerModeSelection): ' + newValue);
-
-    });
+      });
 
 
     //this.tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
     this.tvService
       .getCharacteristic(Characteristic.ActiveIdentifier)
       .on("set", this.setRemoteKey);
-    
+
     this.inputSkyQService = new Service.InputSource("skyq", "Sky Q");
     this.inputSkyQService
       .setCharacteristic(Characteristic.Identifier, 0)
@@ -79,11 +78,9 @@ class SkyQAccessory {
 
     this.tvService.addLinkedService(this.inputSkyQService);
     this.enabledServices.push(this.inputSkyQService);
-  
-
     this.enabledServices.push(this.tvService);
   }
-  
+
   setPowerState(state, callback) {
     this.log.debug("state", state);
     this.remoteControl.press('power', (err)=>{
@@ -95,7 +92,7 @@ class SkyQAccessory {
     this.log.debug("state", "get");
     this.box.getPowerState().then(isOn=>{
       callback(null, isOn);
-    });    
+    });
   }
   setRemoteKey(state, callback) {
     console.log("input", state);
@@ -106,38 +103,38 @@ class SkyQAccessory {
     {
       case Characteristic.RemoteKey.ARROW_UP:
         input_key = 'up';
-        break;
+      break;
       case Characteristic.RemoteKey.ARROW_DOWN:
         input_key = 'down';
-        break;
+      break;
       case Characteristic.RemoteKey.ARROW_LEFT:
         input_key = 'left';
-        break;
+      break;
       case Characteristic.RemoteKey.ARROW_RIGHT:
         input_key = 'right';
-        break;
+      break;
       case Characteristic.RemoteKey.SELECT:
         input_key = 'select';
-        break;
+      break;
       case Characteristic.RemoteKey.EXIT:
         input_key = 'dismiss';
-        break;
+      break;
       case Characteristic.RemoteKey.BACK:
         input_key = 'backup';
-        break;
+      break;
       case Characteristic.RemoteKey.PLAY_PAUSE:
         input_key = 'play';
-        break;
+      break;
       case Characteristic.RemoteKey.INFORMATION:
         input_key = 'i';
-        break;
+      break;
     }
     if(input_key)
-    {
-      this.remoteControl.press(input_key, (err)=>{
-        callback();
-      });
-    } 
+      {
+        this.remoteControl.press(input_key, (err)=>{
+          callback();
+        });
+      }
   }
 
   public getServices() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ class SkyQAccessory {
 
     this.tvService
       .getCharacteristic(Characteristic.RemoteKey)
-      .on("set", this.setRemoteKey);
+      .on("set", this.setRemoteKey.bind(this));
 
     this.tvService
       .getCharacteristic(Characteristic.PowerModeSelection)
@@ -64,7 +64,7 @@ class SkyQAccessory {
     //this.tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
     this.tvService
       .getCharacteristic(Characteristic.ActiveIdentifier)
-      .on("set", this.setRemoteKey);
+      .on("set", this.setRemoteKey.bind(this));
 
     this.inputSkyQService = new Service.InputSource("skyq", "Sky Q");
     this.inputSkyQService
@@ -94,10 +94,10 @@ class SkyQAccessory {
       callback(null, isOn);
     });
   }
+
   setRemoteKey(state, callback) {
     console.log("input", state);
-    var platform = this;
-    platform.log("Setting key state...");
+    this.log("Setting key state...");
     var input_key;
     switch (state)
     {
@@ -129,12 +129,12 @@ class SkyQAccessory {
         input_key = 'i';
       break;
     }
-    if(input_key)
-      {
-        this.remoteControl.press(input_key, (err)=>{
-          callback();
-        });
-      }
+
+    if(input_key){
+      this.remoteControl.press(input_key, (err)=>{
+        callback();
+      });
+    }
   }
 
   public getServices() {


### PR DESCRIPTION
`this` was not bound correctly.

Fixes the below error

```
homebridge-sky-q/dist/index.js:128
      platform.log("Setting key state...");
               ^
TypeError: platform.log is not a function
    at Characteristic.RemoteKey.setRemoteKey (/homebridge/custom_plugins/homebridge-sky-q/dist/index.js:128:16)
    at Characteristic.RemoteKey.emit (events.js:182:13)
    at Characteristic.RemoteKey.Characteristic.setValue (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Characteristic.js:321:10)
    at Bridge.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:873:22)
    at Array.forEach (<anonymous>)
    at Bridge.Accessory._handleSetCharacteristics (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:813:8)
    at HAPServer.emit (events.js:182:13)
    at HAPServer._handleCharacteristics (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/HAPServer.js:972:10)
    at HAPServer.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/HAPServer.js:209:39)
```